### PR TITLE
Add missing ubuntu zlib dependency.

### DIFF
--- a/Dockerfiles/ubuntu
+++ b/Dockerfiles/ubuntu
@@ -4,7 +4,7 @@ FROM ubuntu
 ARG shared=OFF
 
 RUN apt-get update -y
-RUN apt-get -y install build-essential curl git cmake unzip autoconf autogen libtool mlocate \
+RUN apt-get -y install build-essential curl git cmake unzip autoconf autogen libtool mlocate zlib1g-dev \
                        python python3-numpy python3-dev python3-pip python3-wheel
 RUN apt-get -y clean
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains two CMake projects. The [tensorflow_cc](tensorflow_cc) 
 
 ##### Ubuntu 16.04+:
 ```
-sudo apt-get install build-essential curl git cmake unzip autoconf autogen libtool mlocate \
+sudo apt-get install build-essential curl git cmake unzip autoconf autogen libtool mlocate zlib1g-dev \
                      python python3-numpy python3-dev python3-pip python3-wheel
 sudo updatedb
 ```


### PR DESCRIPTION
Fixes the following error during the `cmake ..` step:

```
In file included from tensorflow/core/lib/io/zlib_outputbuffer.cc:16:0:
./tensorflow/core/lib/io/zlib_outputbuffer.h:19:18: fatal error: zlib.h: No such file or directory
```