### PR TITLE
Add missing bazel dependency openjdk-8-jdk.

### DIFF
--- a/Dockerfiles/ubuntu
+++ b/Dockerfiles/ubuntu
@@ -14,7 +14,9 @@ RUN updatedb
 # install bazel for the shared library version
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN apt-get -y update && apt-get -y install bazel
+RUN apt-get -y update \
+ && apt-get -y install openjdk-8-jdk bazel \
+ && apt-get -y clean
 
 # copy the contents of this repository to the container
 COPY . tensorflow_cc


### PR DESCRIPTION
Fixes the following error during the `apt-get install bazel` step by more strictly following the [official installation guide](https://docs.bazel.build/versions/master/install-ubuntu.html#install-on-ubuntu):

```
Errors were encountered while processing:
 /var/cache/apt/archives/openjdk-9-jdk_9~b114-0ubuntu1_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
The command '/bin/sh -c apt-get -y update && apt-get -y -V install bazel' returned a non-zero code: 100
```