### PR TITLE
Optionally use system libprotobuf.so

### DIFF
--- a/tensorflow_cc/CMakeLists.txt
+++ b/tensorflow_cc/CMakeLists.txt
@@ -80,25 +80,6 @@ if(TENSORFLOW_SHARED)
     "${CMAKE_INSTALL_PREFIX}/lib/tensorflow_cc/libtensorflow_framework.so"
     dl pthread
   )
-  if(SYSTEM_PROTOBUF)
-    target_include_directories(
-      tensorflow_cc_shared INTERFACE
-      "${Protobuf_INCLUDE_DIRS}"
-    )
-    target_link_libraries(
-      tensorflow_cc_shared INTERFACE
-      "${Protobuf_LIBRARIES}"
-    )
-  else()
-    target_include_directories(
-      tensorflow_cc_shared INTERFACE
-      "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/gen/protobuf-host/include"
-    )
-    target_link_libraries(
-      tensorflow_cc_shared INTERFACE
-      "${CMAKE_INSTALL_PREFIX}/lib/tensorflow_cc/libprotobuf.a"
-    )
-  endif()
 endif()
 
 # ----------------------------------

--- a/tensorflow_cc/CMakeLists.txt
+++ b/tensorflow_cc/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 # ----------------------------------
 if(SYSTEM_PROTOBUF)
   if(NOT TENSORFLOW_STATIC)
-    message(WARNING "SYSTEM_PROTOBUF is only supported with TENSORFLOW_STATIC.")
+    message(FATAL_ERROR "SYSTEM_PROTOBUF is only supported with TENSORFLOW_STATIC.")
   endif()
   find_package(Protobuf REQUIRED)
 endif()

--- a/tensorflow_cc/CMakeLists.txt
+++ b/tensorflow_cc/CMakeLists.txt
@@ -9,6 +9,8 @@ project(
 # If enabled, bazel has to be installed.
 option(TENSORFLOW_SHARED "Build shared library (required for GPU support)." OFF)
 option(TENSORFLOW_STATIC "Build static library." ON)
+option(SYSTEM_PROTOBUF "Use system protobuf instead of static protobuf from contrib/makefile.\
+ This option is only supported with TENSORFLOW_STATIC." OFF)
 
 # -------------
 # CMake Options
@@ -42,6 +44,16 @@ endif()
 # ----------------------------------
 # Define Shared Tensorflow Interface
 # ----------------------------------
+if(SYSTEM_PROTOBUF)
+  if(NOT TENSORFLOW_STATIC)
+    message(WARNING "SYSTEM_PROTOBUF is only supported with TENSORFLOW_STATIC.")
+  endif()
+  find_package(Protobuf REQUIRED)
+endif()
+
+# ----------------------------------
+# Define Shared Tensorflow Interface
+# ----------------------------------
 
 if(TENSORFLOW_SHARED)
   add_library(tensorflow_cc_shared INTERFACE)
@@ -61,16 +73,32 @@ if(TENSORFLOW_SHARED)
     "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/downloads/eigen"
     "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/downloads/gemmlowp"
     "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/downloads/nsync/public"
-    "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/gen/protobuf-host/include"
   )
   target_link_libraries(
     tensorflow_cc_shared INTERFACE
     "${CMAKE_INSTALL_PREFIX}/lib/tensorflow_cc/libtensorflow_cc.so"
     "${CMAKE_INSTALL_PREFIX}/lib/tensorflow_cc/libtensorflow_framework.so"
-    # static protobuf is used from the contrib/makefile
-    "${CMAKE_INSTALL_PREFIX}/lib/tensorflow_cc/libprotobuf.a"
     dl pthread
   )
+  if(SYSTEM_PROTOBUF)
+    target_include_directories(
+      tensorflow_cc_shared INTERFACE
+      "${Protobuf_INCLUDE_DIRS}"
+    )
+    target_link_libraries(
+      tensorflow_cc_shared INTERFACE
+      "${Protobuf_LIBRARIES}"
+    )
+  else()
+    target_include_directories(
+      tensorflow_cc_shared INTERFACE
+      "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/gen/protobuf-host/include"
+    )
+    target_link_libraries(
+      tensorflow_cc_shared INTERFACE
+      "${CMAKE_INSTALL_PREFIX}/lib/tensorflow_cc/libprotobuf.a"
+    )
+  endif()
 endif()
 
 # ----------------------------------
@@ -95,7 +123,6 @@ if(TENSORFLOW_STATIC)
     "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/downloads/eigen"
     "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/downloads/gemmlowp"
     "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/downloads/nsync/public"
-    "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/gen/protobuf-host/include"
     "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/gen/proto"
     "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/gen/proto_text"
   )
@@ -104,10 +131,28 @@ if(TENSORFLOW_STATIC)
     "-Wl,--allow-multiple-definition"
     "-Wl,--whole-archive ${CMAKE_INSTALL_PREFIX}/lib/tensorflow_cc/libtensorflow-core.a"
     "-Wl,--no-whole-archive"
-    "${CMAKE_INSTALL_PREFIX}/lib/tensorflow_cc/libprotobuf.a"
     "${CMAKE_INSTALL_PREFIX}/lib/tensorflow_cc/nsync.a"
     dl pthread
   )
+  if(SYSTEM_PROTOBUF)
+    target_include_directories(
+      tensorflow_cc_static INTERFACE
+      "${Protobuf_INCLUDE_DIRS}"
+    )
+    target_link_libraries(
+      tensorflow_cc_static INTERFACE
+      "${Protobuf_LIBRARIES}"
+    )
+  else()
+    target_include_directories(
+      tensorflow_cc_static INTERFACE
+      "${CMAKE_INSTALL_PREFIX}/include/tensorflow/tensorflow/contrib/makefile/gen/protobuf-host/include"
+    )
+    target_link_libraries(
+      tensorflow_cc_static INTERFACE
+      "${CMAKE_INSTALL_PREFIX}/lib/tensorflow_cc/libprotobuf.a"
+    )
+  endif()
 endif()
 
 # ----------------------------------------
@@ -148,10 +193,12 @@ install(
   DESTINATION include/tensorflow/third_party
 )
 # install static libprotobuf from contrib/makefile
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/tensorflow/tensorflow/contrib/makefile/gen/protobuf-host/lib/libprotobuf.a"
-  DESTINATION lib/tensorflow_cc
-)
+if (NOT SYSTEM_PROTOBUF)
+  install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/tensorflow/tensorflow/contrib/makefile/gen/protobuf-host/lib/libprotobuf.a"
+    DESTINATION lib/tensorflow_cc
+  )
+endif()
 # shared library specific
 if(TENSORFLOW_SHARED)
   install(


### PR DESCRIPTION
1. Add `-DSYSTEM_PROTOBUF` option defaulted to `OFF`. When it is enabled, the `tensorflow_cc.a` is linked to the `libprotobuf.so` library found in the system instead of the `libprotobuf.a` library built from `contrib/makefile`. This option is only supported for `-DTENSORFLOW_STATIC=ON`.
2. From now on, shared version of `tensorflow_cc` (i.e., `-DTENSORFLOW_SHARED=ON`) **is not explicitly linked to any protobuf**, since it already contains one from bazel.

This relates to #19, #22, #33, and #20. Please test whether this helps you solve your problems.