### PR TITLE
Added extra possible path to CUDA support and compiling with gcc-5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo apt-get install build-essential curl git cmake unzip autoconf autogen libto
 sudo updatedb
 ```
 
-If you require GPU support on Ubuntu, please also install [Bazel](https://bazel.build/), NVIDIA CUDA Toolkit, NVIDIA drivers, cuDNN, and `libcupti-dev` package. The tensorflow build script will automatically detect CUDA if it is installed in `/opt/cuda` or `/usr/local/cuda`directories.
+If you require GPU support on Ubuntu, please also install [Bazel](https://bazel.build/), NVIDIA CUDA Toolkit, NVIDIA drivers, cuDNN, and `libcupti-dev` package. The tensorflow build script will automatically detect CUDA if it is installed in `/opt/cuda` or `/usr/local/cuda` directories.
 
 ##### Arch Linux:
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo apt-get install build-essential curl git cmake unzip autoconf autogen libto
 sudo updatedb
 ```
 
-If you require GPU support on Ubuntu, please also install [Bazel](https://bazel.build/), NVIDIA CUDA Toolkit, NVIDIA drivers, cuDNN, and `libcupti-dev` package. The tensorflow build script will automatically detect CUDA if it is installed in `/opt/cuda` directory.
+If you require GPU support on Ubuntu, please also install [Bazel](https://bazel.build/), NVIDIA CUDA Toolkit, NVIDIA drivers, cuDNN, and `libcupti-dev` package. The tensorflow build script will automatically detect CUDA if it is installed in `/opt/cuda` or `/usr/local/cuda`directories.
 
 ##### Arch Linux:
 ```

--- a/tensorflow_cc/cmake/build_tensorflow.sh
+++ b/tensorflow_cc/cmake/build_tensorflow.sh
@@ -19,17 +19,27 @@ export PYTHON_BIN_PATH="$(which python3)"
 export PYTHON_LIB_PATH="$($PYTHON_BIN_PATH -c 'import site; print(site.getsitepackages()[0])')"
 
 # configure cuda environmental variables
+
 if [ -e /opt/cuda ]; then
+    echo "Using CUDA from /opt/cuda"
+    export CUDA_TOOLKIT_PATH=/opt/cuda
+    export CUDNN_INSTALL_PATH=/opt/cuda
+else if [ -e /usr/local/cuda ]; then
+    echo "Using CUDA from /usr/local/cuda"
+    export CUDA_TOOLKIT_PATH=/usr/local/cuda
+    export CUDNN_INSTALL_PATH=/usr/local/cuda
+fi
+fi
+
+if [ -z ${CUDA_TOOLKIT_PATH+} ]; then
     echo "CUDA support enabled"
     cuda_config_opts="--config=cuda"
     export TF_NEED_CUDA=1
     export TF_CUDA_COMPUTE_CAPABILITIES="3.5,5.2,6.1,6.2"
-    export CUDA_TOOLKIT_PATH=/opt/cuda
-    export CUDNN_INSTALL_PATH=/opt/cuda
     export TF_CUDA_VERSION="$($CUDA_TOOLKIT_PATH/bin/nvcc --version | sed -n 's/^.*release \(.*\),.*/\1/p')"
     export TF_CUDNN_VERSION="$(sed -n 's/^#define CUDNN_MAJOR\s*\(.*\).*/\1/p' $CUDNN_INSTALL_PATH/include/cudnn.h)"
     # use gcc-5 for now, clang in the future
-    export GCC_HOST_COMPILER_PATH=/usr/bin/gcc-6
+    export GCC_HOST_COMPILER_PATH=/usr/bin/gcc-5
     export CLANG_CUDA_COMPILER_PATH=/usr/bin/clang
     export TF_CUDA_CLANG=0
 else

--- a/tensorflow_cc/cmake/build_tensorflow.sh
+++ b/tensorflow_cc/cmake/build_tensorflow.sh
@@ -24,14 +24,13 @@ if [ -e /opt/cuda ]; then
     echo "Using CUDA from /opt/cuda"
     export CUDA_TOOLKIT_PATH=/opt/cuda
     export CUDNN_INSTALL_PATH=/opt/cuda
-else if [ -e /usr/local/cuda ]; then
+elif [ -e /usr/local/cuda ]; then
     echo "Using CUDA from /usr/local/cuda"
     export CUDA_TOOLKIT_PATH=/usr/local/cuda
     export CUDNN_INSTALL_PATH=/usr/local/cuda
 fi
-fi
 
-if [ -z ${CUDA_TOOLKIT_PATH+} ]; then
+if [ -n "${CUDA_TOOLKIT_PATH}" ]; then
     echo "CUDA support enabled"
     cuda_config_opts="--config=cuda"
     export TF_NEED_CUDA=1
@@ -39,7 +38,7 @@ if [ -z ${CUDA_TOOLKIT_PATH+} ]; then
     export TF_CUDA_VERSION="$($CUDA_TOOLKIT_PATH/bin/nvcc --version | sed -n 's/^.*release \(.*\),.*/\1/p')"
     export TF_CUDNN_VERSION="$(sed -n 's/^#define CUDNN_MAJOR\s*\(.*\).*/\1/p' $CUDNN_INSTALL_PATH/include/cudnn.h)"
     # use gcc-5 for now, clang in the future
-    export GCC_HOST_COMPILER_PATH=/usr/bin/gcc-5
+    export GCC_HOST_COMPILER_PATH=/usr/bin/gcc-6
     export CLANG_CUDA_COMPILER_PATH=/usr/bin/clang
     export TF_CUDA_CLANG=0
 else


### PR DESCRIPTION
- When compiling with CUDA support, also allow to search for install in /usr/local/cuda, which is the default install path for NVIDIA install.
- Compile with gcc-5, as gcc-6 is not supported