### PR TITLE
Allow overriding TF variables using env

### DIFF
--- a/tensorflow_cc/cmake/build_tensorflow.sh
+++ b/tensorflow_cc/cmake/build_tensorflow.sh
@@ -2,24 +2,24 @@
 set -e
 
 # configure environmental variables
-export CC_OPT_FLAGS="-march=native"
-export TF_NEED_GCP=0
-export TF_NEED_HDFS=0
-export TF_NEED_OPENCL=0
-export TF_NEED_OPENCL_SYCL=0
-export TF_NEED_TENSORRT=0
-export TF_NEED_JEMALLOC=1
-export TF_NEED_VERBS=0
-export TF_NEED_MKL=1
-export TF_DOWNLOAD_MKL=1
-export TF_NEED_MPI=0
-export TF_ENABLE_XLA=1
-export TF_NEED_S3=0
-export TF_NEED_GDR=0
-export TF_CUDA_CLANG=0
-export TF_SET_ANDROID_WORKSPACE=0
-export TF_NEED_KAFKA=0
-export PYTHON_BIN_PATH="$(which python3)"
+export CC_OPT_FLAGS=${CC_OPT_FLAGS:-"-march=native"}
+export TF_NEED_GCP=${TF_NEED_GCP:-0}
+export TF_NEED_HDFS=${TF_NEED_HDFS:-0}
+export TF_NEED_OPENCL=${TF_NEED_OPENCL:-0}
+export TF_NEED_OPENCL_SYCL=${TF_NEED_OPENCL_SYCL:-0}
+export TF_NEED_TENSORRT=${TF_NEED_TENSORRT:-0}
+export TF_NEED_JEMALLOC=${TF_NEED_JEMALLOC:-1}
+export TF_NEED_VERBS=${TF_NEED_VERBS:-0}
+export TF_NEED_MKL=${TF_NEED_MKL:-1}
+export TF_DOWNLOAD_MKL=${TF_DOWNLOAD_MKL:-1}
+export TF_NEED_MPI=${TF_NEED_MPI:-0}
+export TF_ENABLE_XLA=${TF_ENABLE_XLA:-1}
+export TF_NEED_S3=${TF_NEED_S3:-0}
+export TF_NEED_GDR=${TF_NEED_GDR:-0}
+export TF_CUDA_CLANG=${TF_CUDA_CLANG:-0}
+export TF_SET_ANDROID_WORKSPACE=${TF_SET_ANDROID_WORKSPACE:-0}
+export TF_NEED_KAFKA=${TF_NEED_KAFKA:-0}
+export PYTHON_BIN_PATH=${PYTHON_BIN_PATH:-"$(which python3)"}
 export PYTHON_LIB_PATH="$($PYTHON_BIN_PATH -c 'import site; print(site.getsitepackages()[0])')"
 
 # configure cuda environmental variables
@@ -51,13 +51,13 @@ if [ -n "${CUDA_TOOLKIT_PATH}" ]; then
     echo "CUDA support enabled"
     cuda_config_opts="--config=cuda"
     export TF_NEED_CUDA=1
-    export TF_CUDA_COMPUTE_CAPABILITIES="3.5,5.2,6.1,6.2"
+    export TF_CUDA_COMPUTE_CAPABILITIES=${TF_CUDA_COMPUTE_CAPABILITIES:-"3.5,5.2,6.1,6.2"}
     export TF_CUDA_VERSION="$($CUDA_TOOLKIT_PATH/bin/nvcc --version | sed -n 's/^.*release \(.*\),.*/\1/p')"
     export TF_CUDNN_VERSION="$(sed -n 's/^#define CUDNN_MAJOR\s*\(.*\).*/\1/p' $CUDNN_INSTALL_PATH/include/cudnn.h)"
     # use gcc-6 for now, clang in the future
-    export GCC_HOST_COMPILER_PATH=/usr/bin/gcc-6
-    export CLANG_CUDA_COMPILER_PATH=/usr/bin/clang
-    export TF_CUDA_CLANG=0
+    export GCC_HOST_COMPILER_PATH=${GCC_HOST_COMPILER_PATH:-"/usr/bin/gcc-6"}
+    export CLANG_CUDA_COMPILER_PATH=${CLANG_CUDA_COMPILER_PATH:-"/usr/bin/clang"}
+    export TF_CUDA_CLANG=${TF_CUDA_CLANG:-0}
 else
     echo "CUDA support disabled"
     cuda_config_opts=""


### PR DESCRIPTION
@WilliamTambellini With this, you should be able to override the jemmaloc settings. I have not tested it yet, though.
```
export TF_NEED_JEMALLOC=0
cmake <...> && make <...>
```
Closes #65 