### PR TITLE
stop propagating gcc flags to nvcc

### DIFF
--- a/tensorflow_cc/CMakeLists.txt
+++ b/tensorflow_cc/CMakeLists.txt
@@ -56,7 +56,7 @@ if(TENSORFLOW_SHARED)
   add_library(tensorflow_cc_shared INTERFACE)
   target_compile_options(
     tensorflow_cc_shared INTERFACE
-    "-std=c++11"
+    "$<$<COMPILE_LANGUAGE:CXX>:-std=c++11>"
   )
   add_dependencies(
     tensorflow_cc_shared
@@ -105,7 +105,7 @@ if(TENSORFLOW_STATIC)
   add_library(tensorflow_cc_static INTERFACE)
   target_compile_options(
     tensorflow_cc_static INTERFACE
-    "-std=c++11"
+    "$<$<COMPILE_LANGUAGE:CXX>:-std=c++11>"
   )
   add_dependencies(
     tensorflow_cc_static


### PR DESCRIPTION
We need to stop propagating gcc flags to nvcc. I am using c++14 for both cuda and c++. Tensorflow passed std=c++11 thorough target_compile_options which broke my code. This pull request fixes this issue.

This change requires cmake > 3.3

Similar issue: https://github.com/CGAL/cgal/issues/2775