### PR TITLE
Removing github url warning

### DIFF
--- a/tensorflow_cc/cmake/TensorflowBase.cmake
+++ b/tensorflow_cc/cmake/TensorflowBase.cmake
@@ -3,7 +3,7 @@ include(ExternalProject)
 
 ExternalProject_Add(
   tensorflow_base
-  GIT_REPOSITORY http://github.com/tensorflow/tensorflow.git
+  GIT_REPOSITORY https://github.com/tensorflow/tensorflow.git
   GIT_TAG "${TENSORFLOW_TAG}"
   TMP_DIR "/tmp"
   STAMP_DIR "tensorflow-stamp"


### PR DESCRIPTION
It gives warning as github url should be start with https