### PR TITLE
Option to choose gcc for host compiler

### DIFF
--- a/tensorflow_cc/CMakeLists.txt
+++ b/tensorflow_cc/CMakeLists.txt
@@ -10,8 +10,14 @@ project(
 option(TENSORFLOW_SHARED "Build shared library (required for GPU support)." OFF)
 option(TENSORFLOW_STATIC "Build static library." ON)
 set(TENSORFLOW_TAG "v1.8.0" CACHE STRING "The tensorflow release tag to be checked out (default v1.8.0).")
-set(ENV{GCC_HOST_COMPILER_PATH} "/usr/bin/gcc" CACHE STRING "Please specify which gcc should be used by nvcc as the host compiler (default: /usr/bin/gcc).")
+set(GCC_HOST_COMPILER_PATH "/usr/bin/gcc" CACHE STRING "Please specify which gcc should be used by nvcc as the host compiler (default: /usr/bin/gcc).")
 option(SYSTEM_PROTOBUF "Use system protobuf instead of static protobuf from contrib/makefile." OFF)
+
+# -------------
+# Tensorflow environment file
+# -------------
+file(WRITE "cmake/tensorflow_env.sh" "export GCC_HOST_COMPILER_PATH=${GCC_HOST_COMPILER_PATH}")
+
 
 # -------------
 # CMake Options

--- a/tensorflow_cc/CMakeLists.txt
+++ b/tensorflow_cc/CMakeLists.txt
@@ -10,6 +10,7 @@ project(
 option(TENSORFLOW_SHARED "Build shared library (required for GPU support)." OFF)
 option(TENSORFLOW_STATIC "Build static library." ON)
 set(TENSORFLOW_TAG "v1.8.0" CACHE STRING "The tensorflow release tag to be checked out (default v1.8.0).")
+set(ENV{GCC_HOST_COMPILER_PATH} "/usr/bin/gcc" CACHE STRING "Please specify which gcc should be used by nvcc as the host compiler (default: /usr/bin/gcc).")
 option(SYSTEM_PROTOBUF "Use system protobuf instead of static protobuf from contrib/makefile." OFF)
 
 # -------------

--- a/tensorflow_cc/cmake/TensorflowShared.cmake
+++ b/tensorflow_cc/cmake/TensorflowShared.cmake
@@ -14,9 +14,10 @@ ExternalProject_Add(
             # patch nsync to use g++-5
             COMMAND sed -i "s/ g++/ g++-5/g" tensorflow/contrib/makefile/compile_nsync.sh
             COMMAND tensorflow/contrib/makefile/compile_nsync.sh
+            COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/cmake/tensorflow_env.sh" .
             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_tensorflow.sh" .
-            COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/cmake/copy_links.sh" .
-            COMMAND ./build_tensorflow.sh
+            COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/cmake/copy_links.sh" .            
+            COMMAND ./build_tensorflow.sh 
             COMMAND ./copy_links.sh .
   BUILD_COMMAND ""
   INSTALL_COMMAND ""

--- a/tensorflow_cc/cmake/build_tensorflow.sh
+++ b/tensorflow_cc/cmake/build_tensorflow.sh
@@ -6,6 +6,9 @@ function version_gt {
     test "`printf '%s\n' "$@" | sort -V | head -n 1`" != "$1"
 }
 
+# Grab tensorflow environment set by cmake
+source tensorflow_env.sh
+
 # configure environmental variables
 export CC_OPT_FLAGS=${CC_OPT_FLAGS:-"-march=ivybridge"}
 export TF_NEED_GCP=${TF_NEED_GCP:-0}
@@ -69,6 +72,8 @@ else
     cuda_config_opts=""
     export TF_NEED_CUDA=0
 fi
+
+export GCC_HOST_COMPILER_PATH=${GCC_HOST_COMPILER_PATH}
 
 # configure and build
 ./configure

--- a/tensorflow_cc/cmake/build_tensorflow.sh
+++ b/tensorflow_cc/cmake/build_tensorflow.sh
@@ -62,20 +62,6 @@ if [ -n "${CUDA_TOOLKIT_PATH}" ]; then
     export TF_CUDA_VERSION="$($CUDA_TOOLKIT_PATH/bin/nvcc --version | sed -n 's/^.*release \(.*\),.*/\1/p')"
     export TF_CUDNN_VERSION="$(sed -n 's/^#define CUDNN_MAJOR\s*\(.*\).*/\1/p' $CUDNN_INSTALL_PATH/include/cudnn.h)"
 
-    # choose the right version of CUDA compiler
-    if [ -z "$GCC_HOST_COMPILER_PATH" ]; then
-        if   hash gcc-6 2>/dev/null && version_gt 6.4 `gcc-6 -dumpversion`; then
-            export GCC_HOST_COMPILER_PATH=${GCC_HOST_COMPILER_PATH:-"/usr/bin/gcc-6"}
-        elif hash gcc-5 2>/dev/null && version_gt 5.5 `gcc-5 -dumpversion`; then
-            export GCC_HOST_COMPILER_PATH=${GCC_HOST_COMPILER_PATH:-"/usr/bin/gcc-5"}
-        elif hash gcc-4 2>/dev/null && version_gt 4.9 `gcc-4 -dumpversion`; then
-            export GCC_HOST_COMPILER_PATH=${GCC_HOST_COMPILER_PATH:-"/usr/bin/gcc-4"}
-        else
-            echo "No supported CUDA compiler available."
-            exit 1
-        fi
-    fi
-
     export CLANG_CUDA_COMPILER_PATH=${CLANG_CUDA_COMPILER_PATH:-"/usr/bin/clang"}
     export TF_CUDA_CLANG=${TF_CUDA_CLANG:-0}
 else


### PR DESCRIPTION
Cuda 9.2 is out. Which supports gcc 7 now.

When I tried to run this script, I got error like "No supported CUDA compiler available.". I backtraced it to build_tensorflow where you are manually checking all different gcc version.

I feel it is not a good idea as it's gonna get broken for every cuda major release. It is better to give option to use to choose right version of gcc just like tensorflow does with bazel.