### PR TITLE
Fixes #121 and applies PR 120

### DIFF
--- a/tensorflow_cc/CMakeLists.txt
+++ b/tensorflow_cc/CMakeLists.txt
@@ -178,6 +178,12 @@ install(
   DESTINATION include/tensorflow
   FILES_MATCHING PATTERN "*.h"
 )
+#install the bazel generated files in the correct expected location
+install(
+  DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/tensorflow/bazel-genfiles/genfiles/tensorflow/"
+  DESTINATION include/tensorflow/tensorflow/
+  FILES_MATCHING PATTERN "*.h"
+)
 # install all header files downloaded by contrib/makefile
 # (Note that we cannot simply include all *.h or *.hpp files, since e.g., eigen
 # does not use file extensions for header files.)
@@ -212,7 +218,7 @@ endif()
 # shared library specific
 if(TENSORFLOW_SHARED)
   install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/tensorflow/bazel-bin/tensorflow/libtensorflow_cc.so"
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/tensorflow/bazel-bin/bin/tensorflow/libtensorflow_cc.so"
     DESTINATION lib/tensorflow_cc
   )
 endif()


### PR DESCRIPTION
These are the required fixes to make tensorflow_cc work correctly.

What was missing, was the copy of the generated bazel files in the expected location of other headers and the application of the PR 120.

Closes #121.