### PR TITLE
Add LOCAL_RAM_RESOURCES parameter to CMake

### DIFF
--- a/tensorflow_cc/CMakeLists.txt
+++ b/tensorflow_cc/CMakeLists.txt
@@ -8,6 +8,7 @@ project(
 # If enabled, bazel has to be installed.
 option(ALLOW_CUDA "Try to find and use CUDA." ON)
 option(REQUIRE_CUDA "Make sure to find and use CUDA (implies ALLOW_CUDA)." OFF)
+set(LOCAL_RAM_RESOURCES 4096 CACHE STRING "The amount of local RAM resources passed to bazel (e.g., 4096).")
 set(TENSORFLOW_TAG "v${version}" CACHE STRING "The tensorflow release tag to be checked out (default v${version}).")
 set(TARGET_CXX_STANDARD "cxx_std_11" CACHE STRING "C++ standard to be enforced when linking to TensorflowCC targets (e.g., cxx_std_11).")
 

--- a/tensorflow_cc/cmake/build_tensorflow.sh.in
+++ b/tensorflow_cc/cmake/build_tensorflow.sh.in
@@ -99,6 +99,7 @@ fi
 ./configure
 bazel build --config=opt \
             --config=monolithic \
+            --local_ram_resources=@LOCAL_RAM_RESOURCES@ \
             $cuda_config_opts \
             tensorflow:libtensorflow_cc.so \
             tensorflow:install_headers


### PR DESCRIPTION
Usage example: `cmake -DLOCAL_RAM_RESOURCES=4096 .....`
4096 is default
Closes #227 
