### PR TITLE
Fix problem in CMakeLists.txt crashing when using release candidates

### DIFF
--- a/tensorflow_cc/CMakeLists.txt
+++ b/tensorflow_cc/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/PROJECT_VERSION" version)
 project(
   "tensorflow_cc"
-  VERSION "${version}"
 )
+set(PROJECT_VERSION "${version}")
 
 # If enabled, bazel has to be installed.
 option(ALLOW_CUDA "Try to find and use CUDA." ON)


### PR DESCRIPTION
This should fix the problem of cmake complaining when using release candidates (e.g. 2.5.0-rc0) in PROJECT_VERSION file.

Workaround found here: https://gitlab.kitware.com/cmake/cmake/-/issues/16716

I thought it would be useful...